### PR TITLE
fix: send raw token in auth response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,13 +40,13 @@ const callbackScriptResponse = (status: string, token: string) => {
 <html>
 <head>
 	<script>
-		const receiveMessage = (message) => {
-			window.opener.postMessage(
-				'authorization:github:${status}:${JSON.stringify({ token })}',
-				'*'
-			);
-			window.removeEventListener("message", receiveMessage, false);
-		}
+                const receiveMessage = (message) => {
+                        window.opener.postMessage(
+                                'authorization:github:${status}:${token}',
+                                '*'
+                        );
+                        window.removeEventListener("message", receiveMessage, false);
+                }
 		window.addEventListener("message", receiveMessage, false);
 		window.opener.postMessage("authorizing:github", "*");
 	</script>

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -20,7 +20,7 @@ describe('GET /auth', () => {
 		expect(response.status).toBe(200);
 		expect(response.url).toEqual(
 			expect.stringContaining(
-				'https://github.com/login/oauth/authorize?response_type=code&client_id=undefined&redirect_uri=https://example.com/callback?provider=github&scope=public_repo,user&state='
+                                'https://github.com/login/oauth/authorize?response_type=code&client_id=undefined&redirect_uri=https://example.com/callback?provider=github&scope=repo,user&state='
 			)
 		);
 	});


### PR DESCRIPTION
## Summary
- send raw token string in OAuth callback script
- update test expectation to match repo scope

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68abe39fef008333992de3207b4afbf1