### PR TITLE
Add Cloudflare Pages onRequest handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import type { PagesFunction } from '@cloudflare/workers-types';
 import { OAuthClient } from './oauth';
 
 interface Env {
@@ -90,15 +91,23 @@ const handleCallback = async (url: URL, env: Env) => {
         }
 };
 
+const handleRequest = async (request: Request, env: Env): Promise<Response> => {
+        const url = new URL(request.url);
+        if (url.pathname === '/auth') {
+                return handleAuth(url, env);
+        }
+        if (url.pathname === '/callback') {
+                return handleCallback(url, env);
+        }
+        return new Response('Hello 👋');
+};
+
 export default {
-	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-		const url = new URL(request.url);
-		if (url.pathname === '/auth') {
-			return handleAuth(url, env);
-		}
-		if (url.pathname === '/callback') {
-			return handleCallback(url, env);
-		}
-		return new Response('Hello 👋');
-	},
+        async fetch(request: Request, env: Env): Promise<Response> {
+                return handleRequest(request, env);
+        },
+};
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+        return handleRequest(context.request, context.env);
 };


### PR DESCRIPTION
## Summary
- support Cloudflare Pages by exporting an `onRequest` handler
- test that Pages handler uses environment bindings

## Testing
- `yarn test` *(fails: Failed to load url /workspace/decap-proxy/@cloudflare/vitest-pool-workers)*
- `yarn tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'node:crypto' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ae13c86bb08333a8e679b38f3fb661