### PR TITLE
Simplify decap worker setup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,171 +1,63 @@
-import { randomBytes } from 'node:crypto';
-import type { PagesFunction } from '@cloudflare/workers-types';
-import { OAuthClient } from './oauth';
-
-interface Env {
-  GITHUB_CLIENT_ID: string;
-  GITHUB_CLIENT_SECRET: string;
-}
-
-/** Utils */
-const makeState = () => randomBytes(16).toString('hex');
-
-const getCookie = (cookieHeader: string | null, name: string): string | null => {
-  if (!cookieHeader) return null;
-  const cookies = cookieHeader.split(/; */);
-  for (const c of cookies) {
-    const [k, ...v] = c.split('=');
-    if (k === name) return decodeURIComponent(v.join('='));
-  }
-  return null;
-};
-
-const createOAuth = (env: Env) => {
-  return new OAuthClient({
-    id: env.GITHUB_CLIENT_ID,
-    secret: env.GITHUB_CLIENT_SECRET,
-    target: {
-      tokenHost: 'https://github.com',
-      tokenPath: '/login/oauth/access_token',
-      authorizePath: '/login/oauth/authorize',
-    },
-  });
-};
-
-/** Builds a tiny HTML page that posts a message back to the opener and closes. */
-const callbackScriptResponse = (
-  status: 'success' | 'error',
-  payload: Record<string, string>
-) => {
-  const json = JSON.stringify(payload);
-  return new Response(
-    `<!doctype html>
-<html>
-<head><meta charset="utf-8"></head>
-<body>
-<script>
-  const receiveMessage = () => {
-    window.opener.postMessage('authorization:github:${status}:${json}', '*');
-    window.removeEventListener('message', receiveMessage, false);
-    window.close();
-  };
-  window.addEventListener('message', receiveMessage, false);
-  window.opener?.postMessage('authorizing:github', '*');
-</script>
-<p>Authorizing Decap...</p>
-</body>
-</html>`,
-    {
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-        'Cache-Control': 'no-store',
-      },
-    }
-  );
-};
-
-/** /auth handler: sets state cookie and 302s to GitHub authorize */
-const handleAuth = async (request: Request, env: Env) => {
-  const url = new URL(request.url);
-  const provider = url.searchParams.get('provider');
-  if (provider !== 'github') {
-    return new Response('Invalid provider', { status: 400 });
-  }
-
-  const redirectUri = `${url.origin}/callback?provider=github`;
-  const state = makeState();
-
-  const oauth2 = createOAuth(env);
-  const authorizationUri = oauth2.authorizeURL({
-    redirect_uri: redirectUri,
-    scope: 'repo,user',
-    state,
-  });
-
-  return new Response(null, {
-    status: 302, // use 302, not 301 (avoid caching)
-    headers: {
-      Location: authorizationUri,
-      'Cache-Control': 'no-store',
-      // Cross-site popup requires SameSite=None; Secure
-      'Set-Cookie': `decap_oauth_state=${encodeURIComponent(
-        state
-      )}; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=300`,
-    },
-  });
-};
-
-/** /callback handler: verifies state and exchanges code -> token */
-const handleCallback = async (request: Request, env: Env) => {
-  const url = new URL(request.url);
-  const provider = url.searchParams.get('provider');
-  if (provider !== 'github') {
-    return new Response('Invalid provider', { status: 400 });
-  }
-
-  const code = url.searchParams.get('code');
-  if (!code) {
-    return new Response('Missing code', { status: 400 });
-  }
-
-  const returnedState = url.searchParams.get('state') || '';
-  const cookieState = getCookie(request.headers.get('Cookie'), 'decap_oauth_state') || '';
-  if (!returnedState || !cookieState || returnedState !== cookieState) {
-    return callbackScriptResponse('error', { message: 'invalid_state' });
-  }
-
-  const redirectUri = `${url.origin}/callback?provider=github`;
-  const oauth2 = createOAuth(env);
-
-  try {
-    // Ensure your OAuthClient uses Accept: application/json under the hood.
-    // If not, update it to set that header when calling GitHub.
-    const tokenRes: any = await oauth2.getToken({
-      code,
-      redirect_uri: redirectUri,
-    });
-
-    // Normalize possible shapes
-    const accessToken =
-      typeof tokenRes === 'string'
-        ? tokenRes
-        : tokenRes.access_token ??
-          tokenRes.token?.access_token ??
-          '';
-
-    if (!accessToken) {
-      return callbackScriptResponse('error', { message: 'no_access_token' });
-    }
-
-    // Success: post back to the opener
-    return callbackScriptResponse('success', { token: accessToken });
-  } catch (err: any) {
-    const message = err instanceof Error ? err.message : String(err ?? 'unknown error');
-    return callbackScriptResponse('error', { message });
-  }
-};
-
-/** Router supporting both with/without trailing slashes */
-const handleRequest = async (request: Request, env: Env): Promise<Response> => {
-  const url = new URL(request.url);
-  const path = url.pathname;
-
-  if (path === '/auth' || path === '/auth/') {
-    return handleAuth(request, env);
-  }
-  if (path === '/callback' || path === '/callback/') {
-    return handleCallback(request, env);
-  }
-  return new Response('Hello 👋');
-};
-
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    return handleRequest(request, env);
-  },
-};
+  async fetch(req: Request, env: any) {
+    const url = new URL(req.url);
+    const p = url.pathname;
 
-// Cloudflare Pages Functions entry (optional, keeps Workers + Pages parity)
-export const onRequest: PagesFunction<Env> = async (context) => {
-  return handleRequest(context.request, context.env);
+    if (p === "/auth" || p === "/auth/") {
+      const state = crypto.getRandomValues(new Uint32Array(1))[0].toString(16);
+      const u = new URL("https://github.com/login/oauth/authorize");
+      u.search = new URLSearchParams({
+        response_type: "code",
+        client_id: env.GITHUB_CLIENT_ID,
+        redirect_uri: "https://decap.eighthwayministries.org/callback?provider=github",
+        scope: "repo user",
+        state,
+      }).toString();
+
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: u.toString(),
+          "Set-Cookie": `decap_oauth_state=${state}; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=600`,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+
+    if (p === "/callback" || p === "/callback/") {
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+      const cookie = req.headers.get("Cookie") || "";
+      const m = /(?:^|;\s*)decap_oauth_state=([^;]+)/.exec(cookie);
+      const saved = m ? decodeURIComponent(m[1]) : "";
+
+      const html = (msg: string, extraHeaders: Record<string, string> = {}) =>
+        new Response(`<!doctype html><meta charset="utf-8">
+<script>window.opener&&window.opener.postMessage('${msg}','*');window.close();</script>`,
+        { headers: { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store", ...extraHeaders } });
+
+      if (!code || !state || !saved || state !== saved)
+        return html("authorization:github:error:invalid_state");
+
+      const r = await fetch("https://github.com/login/oauth/access_token", {
+        method: "POST",
+        headers: { "Accept": "application/json" },
+        body: new URLSearchParams({
+          client_id: env.GITHUB_CLIENT_ID,
+          client_secret: env.GITHUB_CLIENT_SECRET,
+          code,
+          redirect_uri: "https://decap.eighthwayministries.org/callback?provider=github",
+        }),
+      });
+      const j = await r.json();
+
+      const msg = j.access_token
+        ? `authorization:github:success:${j.access_token}`
+        : `authorization:github:error:${j.error || "exchange_failed"}`;
+
+      return html(msg, { "Set-Cookie": "decap_oauth_state=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None" });
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
 };

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,64 +1,21 @@
-// test/index.spec.ts
-import { SELF, fetchMock } from 'cloudflare:test';
-import { describe, it, expect, beforeAll } from 'vitest';
-import { onRequest } from '../src/index';
-
-beforeAll(() => {
-	fetchMock.activate();
-	fetchMock.disableNetConnect();
-});
+import { SELF } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
 
 describe('GET /', () => {
-	it('responds with no-op (Hello)', async () => {
-		const response = await SELF.fetch('https://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello 👋"`);
-	});
+  it('responds with 404', async () => {
+    const response = await SELF.fetch('https://example.com/');
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('Not found');
+  });
 });
 
 describe('GET /auth', () => {
-        it('responds with redirected location', async () => {
-                const response = await SELF.fetch('https://example.com/auth?provider=github');
-                expect(response.status).toBe(200);
-                expect(response.url).toEqual(
-                        expect.stringContaining(
-                                'https://github.com/login/oauth/authorize?response_type=code&client_id=Ov23liMHgyLkKUcMYwsj&redirect_uri=https://example.com/callback?provider=github&scope=repo,user&state='
-                        )
-                );
-	});
+  it('redirects to GitHub authorize URL', async () => {
+    const response = await SELF.fetch('https://example.com/auth', { redirect: 'manual' });
+    expect(response.status).toBe(302);
+    const location = response.headers.get('location');
+    expect(location).toMatch(/https:\/\/github.com\/login\/oauth\/authorize/);
+    const cookie = response.headers.get('set-cookie');
+    expect(cookie).toMatch(/decap_oauth_state=/);
+  });
 });
-
-describe('Pages onRequest /auth', () => {
-        it('uses context.env bindings', async () => {
-                const request = new Request('https://example.com/auth?provider=github');
-                const context = {
-                        request,
-                        env: {
-                                GITHUB_CLIENT_ID: 'Ov23liMHgyLkKUcMYwsj',
-                                GITHUB_CLIENT_SECRET: 'secret',
-                        },
-                } as unknown as Parameters<typeof onRequest>[0];
-                const response = await onRequest(context);
-                expect(response.status).toBe(301);
-                expect(response.headers.get('location')).toContain(
-                        'https://github.com/login/oauth/authorize?response_type=code'
-                );
-        });
-});
-
-// TODO: figure out how to mock outbound fetch
-// commented on prior issue: https://github.com/cloudflare/miniflare/issues/609#issuecomment-2079988386
-
-// describe('GET /callback', () => {
-// 	it('responds with html page w/ JS messaging script', async () => {
-// 		fetchMock
-// 			.get('https://example.com')
-// 			.intercept({ path: '/login/oauth/access_token' })
-// 			.reply(200, JSON.stringify({ access_token: 'some-access-token' }));
-
-// 		const response = await SELF.fetch('https://example.com/callback?provider=github&code=some-authorization-code');
-// 		expect(response.status).toBe(200);
-// 		expect(await response.text()).toEqual(
-// 			expect.stringContaining('window.opener.postMessage("authorization:github:success:{"token":"some-access-token"}","*")')
-// 		);
-// 	});
-// });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,114 +1,13 @@
-#:schema node_modules/wrangler/config-schema.json
 name = "decap-proxy"
 main = "src/index.ts"
-compatibility_date = "2024-04-19"
-compatibility_flags = ["nodejs_compat"]
+compatibility_date = "2024-06-01"
 
-workers_dev = false
-route = { pattern = "decap.eighthwayministries.org", zone_name = "eighthwayministries.org", custom_domain = true }
+routes = [
+  { pattern = "decap.eighthwayministries.org/auth*", zone_name = "eighthwayministries.org" },
+  { pattern = "decap.eighthwayministries.org/callback*", zone_name = "eighthwayministries.org" }
+]
 
 [vars]
-GITHUB_CLIENT_ID = "Ov23liMHgyLkKUcMYwsj"
-
-# Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
-# Docs:
-# - https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
-# Note: Use secrets to store sensitive data.
-# - https://developers.cloudflare.com/workers/configuration/secrets/
-
-# Bind the Workers AI model catalog. Run machine learning models, powered by serverless GPUs, on Cloudflare’s global network
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#workers-ai
-# [ai]
-# binding = "AI"
-
-# Bind an Analytics Engine dataset. Use Analytics Engine to write analytics within your Pages Function.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#analytics-engine-datasets
-# [[analytics_engine_datasets]]
-# binding = "MY_DATASET"
-
-# Bind a headless browser instance running on Cloudflare's global network.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#browser-rendering
-# [browser]
-# binding = "MY_BROWSER"
-
-# Bind a D1 database. D1 is Cloudflare’s native serverless SQL database.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#d1-databases
-# [[d1_databases]]
-# binding = "MY_DB"
-# database_name = "my-database"
-# database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-# Bind a dispatch namespace. Use Workers for Platforms to deploy serverless functions programmatically on behalf of your customers.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#dispatch-namespace-bindings-workers-for-platforms
-# [[dispatch_namespaces]]
-# binding = "MY_DISPATCHER"
-# namespace = "my-namespace"
-
-# Bind a Durable Object. Durable objects are a scale-to-zero compute primitive based on the actor model.
-# Durable Objects can live for as long as needed. Use these when you need a long-running "server", such as in realtime apps.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
-# [[durable_objects.bindings]]
-# name = "MY_DURABLE_OBJECT"
-# class_name = "MyDurableObject"
-
-# Durable Object migrations.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
-# [[migrations]]
-# tag = "v1"
-# new_classes = ["MyDurableObject"]
-
-# Bind a Hyperdrive configuration. Use to accelerate access to your existing databases from Cloudflare Workers.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#hyperdrive
-# [[hyperdrive]]
-# binding = "MY_HYPERDRIVE"
-# id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-# Bind a KV Namespace. Use KV as persistent storage for small key-value pairs.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#kv-namespaces
-# [[kv_namespaces]]
-# binding = "MY_KV_NAMESPACE"
-# id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-# Bind an mTLS certificate. Use to present a client certificate when communicating with another service.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#mtls-certificates
-# [[mtls_certificates]]
-# binding = "MY_CERTIFICATE"
-# certificate_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-# Bind a Queue producer. Use this binding to schedule an arbitrary task that may be processed later by a Queue consumer.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#queues
-# [[queues.producers]]
-# binding = "MY_QUEUE"
-# queue = "my-queue"
-
-# Bind a Queue consumer. Queue Consumers can retrieve tasks scheduled by Producers to act on them.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#queues
-# [[queues.consumers]]
-# queue = "my-queue"
-
-# Bind an R2 Bucket. Use R2 to store arbitrarily large blobs of data, such as files.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#r2-buckets
-# [[r2_buckets]]
-# binding = "MY_BUCKET"
-# bucket_name = "my-bucket"
-
-# Bind another Worker service. Use this binding to call another Worker without network overhead.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings
-# [[services]]
-# binding = "MY_SERVICE"
-# service = "my-service"
-
-# Bind a Vectorize index. Use to store and query vector embeddings for semantic search, classification and other vector search use-cases.
-# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#vectorize-indexes
-# [[vectorize]]
-# binding = "MY_INDEX"
-# index_name = "my-index"
-
-
-
-
-
-
-
-
-
+# You can also set these in the dashboard if you prefer
+# GITHUB_CLIENT_ID = "..."
+# GITHUB_CLIENT_SECRET = "..."


### PR DESCRIPTION
## Summary
- streamline wrangler config with explicit auth/callback routes
- replace worker implementation with minimal GitHub OAuth proxy
- update tests for new routing behavior

## Testing
- `yarn test` *(fails: Failed to load url /workspace/decap-proxy/@cloudflare/vitest-pool-workers)*

------
https://chatgpt.com/codex/tasks/task_e_68af07286b908333a3ac18dcbc044fb2